### PR TITLE
Fix: could not update menu item

### DIFF
--- a/app/Application/views/admin/menu/helper/scripts.blade.php
+++ b/app/Application/views/admin/menu/helper/scripts.blade.php
@@ -54,7 +54,7 @@
     function UpdateItem(){
         $(this).preventDefault;
         var data = $('.saveMenus').serialize();
-        $.post("{{ concatenateLangToUrl('admin/updateOneMenuItem/') }}/",data, function(result){
+        $.post("{{ concatenateLangToUrl('admin/updateOneMenuItem/') }}",data, function(result){
             showNotification('<strong>Saving</strong> You have been update this item!');
             $('#defaultModal').modal('hide');
         });


### PR DESCRIPTION
When working on a project in sub-folder, if you edit menu item, save button was not doing anything because of file not found error (it was requesting $ROOT_DOMAIN/$LANG/updateOneMenuItem).